### PR TITLE
Fix IHDR parsing

### DIFF
--- a/chunks/IHDR.js
+++ b/chunks/IHDR.js
@@ -9,11 +9,11 @@ function IHDR(data, offset) {
 
   this.width = this.chunkData.readUInt32BE(0);
   this.height = this.chunkData.readUInt32BE(4);
-  this.bitDepth = this.chunkData.readUInt8(5);
-  this.colorType = this.chunkData.readUInt8(6);
-  this.compressionMethod = this.chunkData.readUInt8(7);
-  this.filterMethod = this.chunkData.readUInt8(8);
-  this.interlaceMethod = this.chunkData.readUInt8(9);
+  this.bitDepth = this.chunkData.readUInt8(8);
+  this.colorType = this.chunkData.readUInt8(9);
+  this.compressionMethod = this.chunkData.readUInt8(10);
+  this.filterMethod = this.chunkData.readUInt8(11);
+  this.interlaceMethod = this.chunkData.readUInt8(12);
 }
 
 util.inherits(IHDR, Chunk);


### PR DESCRIPTION
I don't believe any of the values I am getting out of this library, and I think it's because you are counting the height value as a single byte rather than 4 bytes when reading the bit depth and the following fields.